### PR TITLE
Fix "calibration" -> "calibrate" param

### DIFF
--- a/activities_config_documentation.md
+++ b/activities_config_documentation.md
@@ -191,7 +191,7 @@ for example for detection of markers. Specifying 'true' will result in creating 
 This is optional.
 
 ```json
- "calibration": false,
+ "calibrate": false,
 ```
 
 


### PR DESCRIPTION
I was writing a new activity today and tried to use `"calibration" : true` in the JSON file. The button didn't show up. I changed it `"calibrate" : true` and it worked. So, I'm thinking this is a documentation typo.